### PR TITLE
Update action to use GITHUB_OUTPUT variable for setting output

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -27,5 +27,5 @@ if [ "$?" -ne 0 ]; then
     exit 1
 else
     log "Output: $(cat $OUT_FILE)"
-    echo ::set-output name=output::"$(cat $OUT_FILE)"
+    echo output="$(cat $OUT_FILE)" >> $GITHUB_OUTPUT
 fi


### PR DESCRIPTION
This project currently uses the old way of setting an output with `::set-output`.  This PR updates it to use the new `$GITHUB_OUTPUT` variable.